### PR TITLE
Fix typo in templates

### DIFF
--- a/templates/func.mustache
+++ b/templates/func.mustache
@@ -1,5 +1,5 @@
 {{> institution}}
 {{> mri_scanner_info}}
-For the {{ task_name }} task {{ nb_runs }} of {{scan_type}} {{> mri_sequence_description}} {{ multi_echo }} fMRI data were collected. The acquisiton parameters were: {{ nb_slices }} slices acquired in a {{ so_str }} fashion; {{> common_mri_parameters}} echo time, TE= {{ echo_time }} ms; {{#slice_order}}{{ slice_order }};{{/slice_order}} {{ multiband_factor }}; {{#inplane_accel }}in-plane acceleration factor= {{ inplane_accel }};{{/inplane_accel}} {{> image_size}}
+For the {{ task_name }} task {{ nb_runs }} of {{scan_type}} {{> mri_sequence_description}} {{ multi_echo }} fMRI data were collected. The acquisition parameters were: {{ nb_slices }} slices acquired in a {{ so_str }} fashion; {{> common_mri_parameters}} echo time, TE= {{ echo_time }} ms; {{#slice_order}}{{ slice_order }};{{/slice_order}} {{ multiband_factor }}; {{#inplane_accel }}in-plane acceleration factor= {{ inplane_accel }};{{/inplane_accel}} {{> image_size}}
 Each run was {{ duration }} minutes in length, during which {{ nb_vols }} functional volumes were acquired.
 {{> task}}

--- a/templates/pet.mustache
+++ b/templates/pet.mustache
@@ -3,4 +3,4 @@
 
 The imaging was done using {{TracerRadionuclide}} labelled {{TracerName}} admnistered by {{ModeOfAdministration}} (injected radioactivity: {{InjectedRadioactivity}} {{InjectedRadioactivityUnits}})
 
-The acquisiton parameters were: {{>image_size}}
+The acquisition parameters were: {{>image_size}}


### PR DESCRIPTION
acquisition was misspelled as acquisiton